### PR TITLE
Adjust L2/R2 to be compatible with RG-350/RG-350M OpenDingux software

### DIFF
--- a/drivers/input/keyboard/miyoo_kbd.c
+++ b/drivers/input/keyboard/miyoo_kbd.c
@@ -510,8 +510,8 @@ static void scan_handler(unsigned long unused)
 
     report_key(pre, MY_L1, KEY_TAB);
     report_key(pre, MY_R1, KEY_BACKSPACE);
-    report_key(pre, MY_L2, KEY_RIGHTALT);
-    report_key(pre, MY_R2, KEY_RIGHTSHIFT);
+    report_key(pre, MY_L2, KEY_PAGEUP);
+    report_key(pre, MY_R2, KEY_PAGEDOWN);
 	
     input_sync(mydev);
     hotkey_mod_last = false;


### PR DESCRIPTION
Adjust L2/R2 to be compatible with RG-350/RG-350M OpenDingux software on a source code basis.

We really want to avoid a disaster where people are going to modify the source code solely to change the input
to match the RG-350 ports.
Given that it is also adopted by the upstream OpenDingux mainline (see here : https://github.com/OpenDingux/linux/blob/jz-5.9/arch/mips/boot/dts/ingenic/rg350.dts#L246), change it accordingly.