### PR TITLE
Dt fixes

### DIFF
--- a/arch/arm/boot/dts/suniv-f1c500s-miyoo.dts
+++ b/arch/arm/boot/dts/suniv-f1c500s-miyoo.dts
@@ -22,7 +22,7 @@
 	
   backlight {
 		compatible = "pwm-backlight";
-		pwms = <&pwm 1 1000000 0>;
+		pwms = <&pwm 1 58824 0>;
 		brightness-levels = <0 10 20 30 40 50 60 70 80 90 100>;
 		default-brightness-level = <5>;
 		status = "okay";

--- a/arch/arm/boot/dts/suniv.dtsi
+++ b/arch/arm/boot/dts/suniv.dtsi
@@ -89,7 +89,7 @@
 		};
 
 		tcon0: tcon0@1c0c000 {
-			compatible = "allwinner,suniv-f1c500s,r61520";
+			compatible = "allwinner,suniv-f1c500s-tcon0";
 			reg = <0x01c0c000 0x1000>;
 			interrupts = <29>;
 			clocks = <&ccu CLK_BUS_LCD>, <&ccu CLK_TCON>;


### PR DESCRIPTION
Here are two fix to produce the same device tree than on Bittboy_V3.5_CFW_V1.3.3_04-10-20.img image.

One is necessary to have a working kernel and the other one is not (related to reduce noise from the backlight ?)