### PR TITLE
Allow forcing display version

### DIFF
--- a/drivers/video/fbdev/r61520fb.c
+++ b/drivers/video/fbdev/r61520fb.c
@@ -73,6 +73,7 @@ module_param(flip,bool,0660);
 // 2 = ? - Might be a R61526 or a R61581. It's NOT a R61520, because that one doesn't support the 0x04 read_DDB_start / Read Display ID Information command.
 // 3 = ?
 // 4 = ?
+// Will be automatically detected if left unset (which usually works)
 static uint32_t version=0;
 module_param(version,uint,0660);
 


### PR DESCRIPTION
This adds a new `version` option for the `insmod` command when loading the `r61520fb.ko` display controller driver.

Usage: determine the correct version (1-4) by reading `dmesg` output after a successful boot. The line will look something like this:

```
[    1.900000] miyoo panel config as v2
```

Then update `modules.custom.sh` like so:

```
if test -e "./flip"; then
    insmod "./r61520fb.ko" flip=1 version=2
else
    insmod "./r61520fb.ko" version=2
fi
```

If unset, the version will be automatically detected. If set, the set version will be used, but the auto-detection logic will still run and log a warning if it comes up with a different answer.

---

Setting mine to 1 replicates the behavior I was seeing previously of the display going blank after uboot, but still hearing the "ding". Setting it to 2 seems to work every time I turn it on, although I've only tried a few times.

---

Caveats: 

1. I suck at writing C code
2. I've literally never written any code related to the linux kernel before this