### PR TITLE
Set up CI build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,62 @@
+# based on https://github.com/nfriedly/gmenunx/blob/ci/.github/workflows/c-cpp.yml
+name: CI Build
+
+on: [push, pull_request]
+
+jobs:   
+  build-modern:
+    name: MiyooCFW Linux kernel (musl libc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:latest
+    steps:
+    - uses: actions/checkout@v2
+    # ARCH=arm and CROSS_COMPILE=arm-buildroot-linux-musleabi- env props are set in the docker image
+    - name: build devicetree
+      run: make miyoo_defconfig
+    - name: build zImage
+      run: make zImage
+    - name: build drivers
+      run: make M=$PwD
+    # put everything in the same folder so that we can grab it all as a single artifact
+    - name: gather files
+      run: |
+        mkdir dist
+        mv arch/arm/boot/dts/suniv-f1c500s-miyoo.dts dist/
+        mv arch/arm/boot/zImage dist/
+        # todo: do we want crypto/echainiv.ko ? if not, why are we compiling it?
+        mv drivers/video/fbdev/core/*.ko dist/
+        mv drivers/video/fbdev/r61520fb.ko dist/
+    - uses: actions/upload-artifact@v2
+      with:
+        name: MiyooCFW Linux kernel
+        path: dist/*
+        if-no-files-found: error # 'error', 'warn', 'ignore'; defaults to `warn`
+
+  # note: this compiles successfully, but it's not a drop-in replacement for the 1.3.3 kernel
+  build-legacy:
+    name: Legacy MiyooCFW Linux kernel (uClibc)
+    runs-on: ubuntu-20.04
+    container:
+      image: nfriedly/miyoo-toolchain:steward
+    steps:
+    - uses: actions/checkout@v2
+    # env props from docker image: ARCH=arm CROSS_COMPILE=arm-miyoo-linux-uclibcgnueabi-
+    - name: build devicetree
+      run: make miyoo_defconfig
+    - name: build zImage
+      run: make zImage
+    - name: build drivers
+      run: make M=$PwD
+    - name: gather files
+      run: |
+        mkdir dist
+        mv arch/arm/boot/dts/suniv-f1c500s-miyoo.dts dist/
+        mv arch/arm/boot/zImage dist/
+        mv drivers/video/fbdev/core/*.ko dist/
+        mv drivers/video/fbdev/r61520fb.ko dist/
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Legacy MiyooCFW Linux kernel
+        path: dist/*
+        if-no-files-found: error


### PR DESCRIPTION
Makes the config, kernel, devicetree, &  drivers with both the steward and musl toolchains.

I tested and confirmed both work with the mainboot repo.

I also tried the steward/uClibc one with 1.3.3 but it couldn't display anything after the uboot splash. I think it's because the video driver was bundled into the kernel in 1.3.3(?) There's probably a straightforward fix for that, but I'm not sure what it is off the top of my head.

In good news, the file sizes are very close for both builds :)