### PR TITLE
update hotkeys for SUP M3 and XYC Q8

### DIFF
--- a/drivers/input/keyboard/miyoo_kbd.c
+++ b/drivers/input/keyboard/miyoo_kbd.c
@@ -375,10 +375,10 @@ static void scan_handler(unsigned long unused)
               val|= MY_LEFT;
           }
           if(gpio_get_value(IN_A_M3) == 1){
-              val|= MY_TA;
+              val|= MY_TB;
           }
           if(gpio_get_value(IN_PA1) == 1){
-              val|= MY_TB;
+              val|= MY_B;
           }
 
           gpio_direction_input(IN_3);
@@ -390,10 +390,10 @@ static void scan_handler(unsigned long unused)
               val|= MY_RIGHT;
           }
           if(gpio_get_value(IN_A_M3) == 1){
-              val|= MY_A;
+              val|= MY_TA;
           }
           if(gpio_get_value(IN_PA1) == 1){
-              val|= MY_B;
+              val|= MY_A;
           }
 
           gpio_direction_input(IN_4);
@@ -564,13 +564,13 @@ static void scan_handler(unsigned long unused)
   } else if(miyoo_ver == 3) {
     if((val & MY_R) && (val & MY_L1)) {
       val&= ~MY_R;
-      val&= ~MY_TB;
+      val&= ~MY_L1;
       val|= MY_L2;
       hotkey_actioned = true;
     }
     if((val & MY_R) && (val & MY_R1)) {
       val&= ~MY_R;
-      val&= ~MY_TA;
+      val&= ~MY_R1;
       val|= MY_R2;
       hotkey_actioned = true;
     }

--- a/drivers/input/keyboard/miyoo_kbd.c
+++ b/drivers/input/keyboard/miyoo_kbd.c
@@ -561,6 +561,31 @@ static void scan_handler(unsigned long unused)
       val|= MY_R2;
       hotkey_actioned = true;
     }
+  } else if(miyoo_ver == 3) {
+    if((val & MY_R) && (val & MY_L1)) {
+      val&= ~MY_R;
+      val&= ~MY_TB;
+      val|= MY_L2;
+      hotkey_actioned = true;
+    }
+    if((val & MY_R) && (val & MY_R1)) {
+      val&= ~MY_R;
+      val&= ~MY_TA;
+      val|= MY_R2;
+      hotkey_actioned = true;
+    }
+    if((val & MY_R) && (val & MY_TB)) {
+      val&= ~MY_R;
+      val&= ~MY_TB;
+      val|= MY_R3;
+      hotkey_actioned = true;
+    }
+    if((val & MY_R) && (val & MY_B)) {
+      val&= ~MY_R
+      val&= ~MY_B;
+      val|= MY_L3;
+      hotkey_actioned = true;
+    }
   } else if(miyoo_ver == 4) {
     if((val & MY_R) && (val & MY_TA)) {
       if(!hotkey_down) {
@@ -578,15 +603,27 @@ static void scan_handler(unsigned long unused)
       }
       hotkey_actioned = true;   
     }
-    if((val & MY_R) && (val & MY_L1)) {
+    if((val & MY_R) && (val & MY_TB)) {
       val&= ~MY_R;
       val&= ~MY_TB;
+      val|= MY_R3;
+      hotkey_actioned = true;
+    }
+    if((val & MY_R) && (val & MY_B)) {
+      val&= ~MY_R;
+      val&= ~MY_B;
+      val|= MY_L3
+      hotkey_actioned = true;
+    }
+    if((val & MY_R) && (val & MY_L1)) {
+      val&= ~MY_R;
+      val&= ~MY_L1;
       val|= MY_L2;
       hotkey_actioned = true;
     }
     if((val & MY_R) && (val & MY_R1)) {
       val&= ~MY_R;
-      val&= ~MY_TA;
+      val&= ~MY_R1;
       val|= MY_R2;
       hotkey_actioned = true;
     }
@@ -689,25 +726,25 @@ static void scan_handler(unsigned long unused)
 
   if(val & MY_R && !non_hotkey_first) {
 	  if((val & MY_R) && (val & MY_B)){
-      if(miyoo_ver == 2 || miyoo_ver == 5 || miyoo_ver == 6)  {
+      if(miyoo_ver != 1)  {
 			  hotkey_actioned = true;
 	  	  hotkey = hotkey == 0 ? 3 : hotkey;
       }
 	 	}
 	 	else if((val & MY_R) && (val & MY_A)){
-      if(miyoo_ver == 2 || miyoo_ver == 5 || miyoo_ver == 6)  {
+      if(miyoo_ver != 1)  {
 	  	  hotkey_actioned = true;
 	  	  hotkey = hotkey == 0 ? 4 : hotkey;
       }
 	 	}
 		else if((val & MY_R) && (val & MY_TB)){
-      if(miyoo_ver == 2 || miyoo_ver == 5 || miyoo_ver == 6)  {
+      if(miyoo_ver != 1)  {
         hotkey_actioned = true;
         hotkey = hotkey == 0 ? 1 : hotkey;
       }
 		}
 		else if((val & MY_R) && (val & MY_TA)){
-      if(miyoo_ver == 2 || miyoo_ver == 5 || miyoo_ver == 6)  {
+      if(miyoo_ver != 1)  {
         hotkey_actioned = true;
         hotkey = hotkey == 0 ? 2 : hotkey;
       }

--- a/drivers/input/keyboard/miyoo_kbd.c
+++ b/drivers/input/keyboard/miyoo_kbd.c
@@ -726,25 +726,25 @@ static void scan_handler(unsigned long unused)
 
   if(val & MY_R && !non_hotkey_first) {
 	  if((val & MY_R) && (val & MY_B)){
-      if(miyoo_ver != 1)  {
+      if(miyoo_ver == 2 || miyoo_ver == 5 || miyoo_ver == 6)  {
 			  hotkey_actioned = true;
 	  	  hotkey = hotkey == 0 ? 3 : hotkey;
       }
 	 	}
 	 	else if((val & MY_R) && (val & MY_A)){
-      if(miyoo_ver != 1)  {
+      if(miyoo_ver == 2 || miyoo_ver == 3 || miyoo_ver == 5 || miyoo_ver == 6)  {
 	  	  hotkey_actioned = true;
 	  	  hotkey = hotkey == 0 ? 4 : hotkey;
       }
 	 	}
 		else if((val & MY_R) && (val & MY_TB)){
-      if(miyoo_ver != 1)  {
+      if(miyoo_ver == 2 || miyoo_ver == 5 || miyoo_ver == 6)  {
         hotkey_actioned = true;
         hotkey = hotkey == 0 ? 1 : hotkey;
       }
 		}
 		else if((val & MY_R) && (val & MY_TA)){
-      if(miyoo_ver != 1)  {
+      if(miyoo_ver == 2 || miyoo_ver == 3 || miyoo_ver == 5 || miyoo_ver == 6)  {
         hotkey_actioned = true;
         hotkey = hotkey == 0 ? 2 : hotkey;
       }

--- a/drivers/input/keyboard/miyoo_kbd.c
+++ b/drivers/input/keyboard/miyoo_kbd.c
@@ -581,7 +581,7 @@ static void scan_handler(unsigned long unused)
       hotkey_actioned = true;
     }
     if((val & MY_R) && (val & MY_B)) {
-      val&= ~MY_R
+      val&= ~MY_R;
       val&= ~MY_B;
       val|= MY_L3;
       hotkey_actioned = true;
@@ -612,7 +612,7 @@ static void scan_handler(unsigned long unused)
     if((val & MY_R) && (val & MY_B)) {
       val&= ~MY_R;
       val&= ~MY_B;
-      val|= MY_L3
+      val|= MY_L3;
       hotkey_actioned = true;
     }
     if((val & MY_R) && (val & MY_L1)) {


### PR DESCRIPTION
## Updated hotkeys:
XYC Q8 (miyoo_ver == 4)
- add simulated L3/R3 under VOL+Y/X 

SUP M3 (miyoo_ver == 3)
- move simulated L2/R2 under HOME+L1/R1
- add simulated L3/R3 under HOME+Y/X

## Revamped default keys on SUP M3:
Make it cohesive with actual naming on the front plate & with emulators default key bindings like for PocketGO, see pic:
![image](https://user-images.githubusercontent.com/94932128/221970345-58fc3339-58c0-42e8-89e9-c6d4880d1787.png)

