### PR TITLE
[PWM-SUNIV] inline rumble for motor_ver=2 with 3&4

### DIFF
--- a/drivers/pwm/pwm-suniv.c
+++ b/drivers/pwm/pwm-suniv.c
@@ -349,8 +349,7 @@ static int get_motor_pin(int ver)
   switch(ver){
   case 1:
     return ((32 * 4) + 1);
-  case 4:
-  case 3:
+  case 2: case 3: case 4:
     return ((32 * 4) + 12);
   }
   return -1;


### PR DESCRIPTION
On legacy CFW the kernel/daemon sets miyoo motor config as v3 (when miyoo panel is v2), should be the same as setting both to v2. This just enables rumble pin and sets motor_ver != 1 , when miyoo_ver = 2