### PR TITLE
Video: Enable 3- and 4-layer support for all Miyoo video drivers

### DIFF
--- a/drivers/video/fbdev/gc9306fb.c
+++ b/drivers/video/fbdev/gc9306fb.c
@@ -180,14 +180,30 @@ static void lcdc_wr_dat(uint32_t cmd)
 
 static void refresh_lcd(struct myfb_par *par)
 {
-    if(par->yoffset == 0){
-        suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-        suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-    }
-    else{
-        suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-        suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-    }
+	if(par->yoffset == 0) {
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 240) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 480) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 720) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	} 
     suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 0));
     suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (1 << 31));
 }
@@ -344,65 +360,76 @@ static void init_lcd(void)
 
 static void suniv_lcdc_init(struct myfb_par *par)
 {
-    uint32_t ret=0, p1=0, p2=0;
+	uint32_t ret=0, p1=0, p2=0;
 
-    writel(0, iomm.lcdc + TCON_CTRL_REG);
-    writel(0, iomm.lcdc + TCON_INT_REG0);
-    ret = readl(iomm.lcdc + TCON_CLK_CTRL_REG);
-    ret&= ~(0xf << 28);
-    writel(ret, iomm.lcdc + TCON_CLK_CTRL_REG);
-    writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
-    writel(0xffffffff, iomm.lcdc + TCON1_IO_CTRL_REG1);
+	writel(0, iomm.lcdc + TCON_CTRL_REG);
+	writel(0, iomm.lcdc + TCON_INT_REG0);
+	ret = readl(iomm.lcdc + TCON_CLK_CTRL_REG);
+	ret&= ~(0xf << 28);
+	writel(ret, iomm.lcdc + TCON_CLK_CTRL_REG);
+	writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
+	writel(0xffffffff, iomm.lcdc + TCON1_IO_CTRL_REG1);
 
-    suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 0));
-    writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
-    writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
-    writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_DISP_SIZE_REG);
-    writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY0_SIZE_REG);
-    writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY1_SIZE_REG);
-    writel((5 << 8), iomm.debe + DEBE_LAY0_ATT_CTRL_REG1);
-    writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
-    suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-    suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 1));
-    suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
+	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 0));
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY2_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY3_LINEWIDTH_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_DISP_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY0_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY1_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY2_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY3_SIZE_REG);
+	writel((5 << 8), iomm.debe + DEBE_LAY0_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY2_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY3_ATT_CTRL_REG1);
+	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 1));
+	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
 
-    ret = readl(iomm.lcdc + TCON_CTRL_REG);
-    ret&= ~(1 << 0);
-    writel(ret, iomm.lcdc + TCON_CTRL_REG);
-    ret = (1 + 1 + 1);
-    writel((uint32_t)(par->vram_phys) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
-    writel((uint32_t)(par->vram_phys+ 320*240*2) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys+ 320*240*2) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	ret = readl(iomm.lcdc + TCON_CTRL_REG);
+	ret&= ~(1 << 0);
+	writel(ret, iomm.lcdc + TCON_CTRL_REG);
+	ret = (1 + 1 + 1);
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) << 3, iomm.debe + DEBE_LAY2_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) << 3, iomm.debe + DEBE_LAY3_FB_ADDR_REG);
 
-    writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
-    writel((0xf << 28) | (25 << 0), iomm.lcdc + TCON_CLK_CTRL_REG); //6, 15, 25
-    writel((4 << 29) | (1 << 26), iomm.lcdc + TCON0_CPU_IF_REG);
-    writel((1 << 28), iomm.lcdc + TCON0_IO_CTRL_REG0);
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) >> 29, iomm.debe + DEBE_LAY2_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) >> 29, iomm.debe + DEBE_LAY3_FB_HI_ADDR_REG);	
 
-    p1 = par->mode.yres - 1;
-    p2 = par->mode.xres - 1;
-    writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG0);
+	writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
+	writel((0xf << 28) | (25 << 0), iomm.lcdc + TCON_CLK_CTRL_REG); //6, 15, 25
+	writel((4 << 29) | (1 << 26), iomm.lcdc + TCON0_CPU_IF_REG);
+	writel((1 << 28), iomm.lcdc + TCON0_IO_CTRL_REG0);
 
-    p1 = 1 + 1;
-    p2 = 1 + 1 + par->mode.xres + 2;
-    writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG1);
+	p1 = par->mode.yres - 1;
+	p2 = par->mode.xres - 1;
+	writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG0);
 
-    p1 = 1 + 1;
-    p2 = (1 + 1 + par->mode.yres + 1 + 2) << 1;
-    writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG2);
+	p1 = 1 + 1;
+	p2 = 1 + 1 + par->mode.xres + 2;
+	writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG1);
 
-    p1 = 1 + 1;
-    p2 = 1 + 1;
-    writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG3);
+	p1 = 1 + 1;
+	p2 = (1 + 1 + par->mode.yres + 1 + 2) << 1;
+	writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG2);
 
-    writel(0, iomm.lcdc + TCON0_HV_TIMING_REG);
-    writel(0, iomm.lcdc + TCON0_IO_CTRL_REG1);
+	p1 = 1 + 1;
+	p2 = 1 + 1;
+	writel((p2 << 16) | (p1 << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG3);
 
-    suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (1 << 31));
-    init_lcd();
-    suniv_setbits(iomm.lcdc + TCON_INT_REG0, (1 << 31));
-    suniv_setbits(iomm.lcdc + TCON0_CPU_IF_REG, (1 << 28));
+	writel(0, iomm.lcdc + TCON0_HV_TIMING_REG);
+	writel(0, iomm.lcdc + TCON0_IO_CTRL_REG1);
+
+	suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (1 << 31));
+	init_lcd();
+	suniv_setbits(iomm.lcdc + TCON_INT_REG0, (1 << 31));
+	suniv_setbits(iomm.lcdc + TCON0_CPU_IF_REG, (1 << 28));
 }
 
 static void suniv_enable_irq(struct myfb_par *par)

--- a/drivers/video/fbdev/hx8347dfb.c
+++ b/drivers/video/fbdev/hx8347dfb.c
@@ -205,14 +205,30 @@ static void refresh_lcd(struct myfb_par *par)
 
     lcdc_wr_cmd(0x22);
 
-  if(par->yoffset == 0){
-	  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	  suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-  }
-  else{
-	  suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-  }
+	if(par->yoffset == 0) {
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 240) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 480) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 720) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	} 
 	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 0));
 }
 
@@ -473,45 +489,56 @@ static void suniv_enable_irq(struct myfb_par *par)
 
 static void suniv_lcdc_init(struct myfb_par *par)
 {
-  uint32_t ret=0, bp=0, total=0;
+	uint32_t ret=0, bp=0, total=0;
 	uint32_t h_front_porch = 8;
 	uint32_t h_back_porch = 8;
 	uint32_t h_sync_len = 1;
 	uint32_t v_front_porch = 8;
 	uint32_t v_back_porch = 8;
 	uint32_t v_sync_len = 1;
- 
+
 	writel(0, iomm.lcdc + TCON_CTRL_REG);
 	writel(0, iomm.lcdc + TCON_INT_REG0);
 	ret = readl(iomm.lcdc + TCON_CLK_CTRL_REG);
 	ret&= ~(0xf << 28);
 	writel(ret, iomm.lcdc + TCON_CLK_CTRL_REG);
-  writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
+	writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
 	writel(0xffffffff, iomm.lcdc + TCON1_IO_CTRL_REG1);
 
 	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 0));
-  writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
-  writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY2_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY3_LINEWIDTH_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_DISP_SIZE_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY0_SIZE_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY1_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY2_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY3_SIZE_REG);
 	writel((5 << 8), iomm.debe + DEBE_LAY0_ATT_CTRL_REG1);
-  writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY2_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY3_ATT_CTRL_REG1);
 	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
 	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 1));
-  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
+	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
 
 	ret = readl(iomm.lcdc + TCON_CTRL_REG);
 	ret&= ~(1 << 0);
 	writel(ret, iomm.lcdc + TCON_CTRL_REG);
 	ret = (v_front_porch + v_back_porch + v_sync_len);
 
-    writel((uint32_t)(par->vram_phys) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
-    writel((uint32_t)(par->vram_phys + 320*240*2) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys + 320*240*2) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) << 3, iomm.debe + DEBE_LAY2_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) << 3, iomm.debe + DEBE_LAY3_FB_ADDR_REG);
+
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) >> 29, iomm.debe + DEBE_LAY2_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) >> 29, iomm.debe + DEBE_LAY3_FB_HI_ADDR_REG);	
 	  
-    writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
+	writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
 	  writel((0xf << 28) | (6 << 0), iomm.lcdc + TCON_CLK_CTRL_REG); // 6, 15
 	  writel((4 << 29) | (1 << 26), iomm.lcdc + TCON0_CPU_IF_REG);
 	  writel((1 << 28), iomm.lcdc + TCON0_IO_CTRL_REG0);
@@ -527,9 +554,9 @@ static void suniv_lcdc_init(struct myfb_par *par)
 	writel(((h_sync_len - 1) << 16) | ((v_sync_len - 1) << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG3);
 	writel(0, iomm.lcdc + TCON0_HV_TIMING_REG);
 	writel(0, iomm.lcdc + TCON0_IO_CTRL_REG1);	
-  
+
 	suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (1 << 31));
-  suniv_setbits(iomm.gpio + PE_INT_STA, (1 << 10));
+	suniv_setbits(iomm.gpio + PE_INT_STA, (1 << 10));
 	suniv_setbits(iomm.lcdc + TCON_INT_REG0, (1 << 31));
 	suniv_setbits(iomm.lcdc + TCON0_CPU_IF_REG, (1 << 28));
 }

--- a/drivers/video/fbdev/r61520fb.c
+++ b/drivers/video/fbdev/r61520fb.c
@@ -360,17 +360,33 @@ static void gpio_wr_dat(uint32_t val)
 
 static void refresh_lcd(struct myfb_par *par)
 {
-  if((miyoo_ver <= 2) || (miyoo_ver == 4)){
-    lcdc_wr_cmd(0x2c);
-  }
-  if(par->yoffset == 0){
-	  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	  suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-  }
-  else{
-	  suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-  }
+	if((miyoo_ver <= 2) || (miyoo_ver == 4)){
+		lcdc_wr_cmd(0x2c);
+	}
+	if(par->yoffset == 0) {
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 240) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 480) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 720) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}  
 	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 0));
 }
 
@@ -1235,29 +1251,35 @@ static void suniv_lcdc_init(struct myfb_par *par)
     printk("Warning: LCD controller not detected as version 4, but being overridden by module_param as version 4 (detection 1 of 2)");
     ver = version;
   }
-    suniv_setbits(iomm.lcdc + TCON1_CTRL_REG, (0 << 31));
-    suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (0 << 31));
+	suniv_setbits(iomm.lcdc + TCON1_CTRL_REG, (0 << 31));
+	suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (0 << 31));
 	writel(0, iomm.lcdc + TCON_CTRL_REG);
 	writel(0, iomm.lcdc + TCON_INT_REG0);
 	ret = readl(iomm.lcdc + TCON_CLK_CTRL_REG);
 	ret&= ~(0xf << 28);
 	writel(ret, iomm.lcdc + TCON_CLK_CTRL_REG);
-  writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
+	writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
 	writel(0xffffffff, iomm.lcdc + TCON1_IO_CTRL_REG1);
 
 	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 0));
-  writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
-  writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY2_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY3_LINEWIDTH_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_DISP_SIZE_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY0_SIZE_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY1_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY2_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY3_SIZE_REG);
 	writel((5 << 8), iomm.debe + DEBE_LAY0_ATT_CTRL_REG1);
-  writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
-    ret = readl(iomm.debe + DEBE_LAY0_ATT_CTRL_REG0 ) & ~(3 << 1);
-    writel(ret | (0 << 1), iomm.debe + DEBE_LAY0_ATT_CTRL_REG0);
+	writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY2_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY3_ATT_CTRL_REG1);
+	ret = readl(iomm.debe + DEBE_LAY0_ATT_CTRL_REG0 ) & ~(3 << 1);
+	writel(ret | (0 << 1), iomm.debe + DEBE_LAY0_ATT_CTRL_REG0);
 	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
 	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 1));
-  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
+	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
 
 	ret = readl(iomm.lcdc + TCON_CTRL_REG);
 	ret&= ~(1 << 0);
@@ -1313,11 +1335,16 @@ static void suniv_lcdc_init(struct myfb_par *par)
     //suniv_setbits(iomm.gpio + PE_CFG0, 1 << 21);
     //suniv_clrbits(iomm.gpio + PE_CFG0, 1 << 22);
   }
-  else{
-    writel((uint32_t)(par->vram_phys) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
-    writel((uint32_t)(par->vram_phys + 320*240*2) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys + 320*240*2) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+  else{	
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) << 3, iomm.debe + DEBE_LAY2_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) << 3, iomm.debe + DEBE_LAY3_FB_ADDR_REG);
+
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) >> 29, iomm.debe + DEBE_LAY2_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) >> 29, iomm.debe + DEBE_LAY3_FB_HI_ADDR_REG);	
 	  
     writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
 	  writel((0xf << 28) | (6 << 0), iomm.lcdc + TCON_CLK_CTRL_REG); // 6, 15

--- a/drivers/video/fbdev/rm68090fb.c
+++ b/drivers/video/fbdev/rm68090fb.c
@@ -205,14 +205,30 @@ static void refresh_lcd(struct myfb_par *par)
 
     lcdc_wr_cmd(0x22);
 
-  if(par->yoffset == 0){
-	  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	  suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-  }
-  else{
-	  suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-  }
+	if(par->yoffset == 0) {
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 240) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 480) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	}
+	else if(par->yoffset == 720) {
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+		suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+	} 
 	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 0));
 }
 
@@ -407,45 +423,56 @@ static void suniv_enable_irq(struct myfb_par *par)
 
 static void suniv_lcdc_init(struct myfb_par *par)
 {
-  uint32_t ret=0, bp=0, total=0;
+	uint32_t ret=0, bp=0, total=0;
 	uint32_t h_front_porch = 8;
 	uint32_t h_back_porch = 8;
 	uint32_t h_sync_len = 1;
 	uint32_t v_front_porch = 8;
 	uint32_t v_back_porch = 8;
 	uint32_t v_sync_len = 1;
- 
+
 	writel(0, iomm.lcdc + TCON_CTRL_REG);
 	writel(0, iomm.lcdc + TCON_INT_REG0);
 	ret = readl(iomm.lcdc + TCON_CLK_CTRL_REG);
 	ret&= ~(0xf << 28);
 	writel(ret, iomm.lcdc + TCON_CLK_CTRL_REG);
-  writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
+	writel(0xffffffff, iomm.lcdc + TCON0_IO_CTRL_REG1);
 	writel(0xffffffff, iomm.lcdc + TCON1_IO_CTRL_REG1);
 
 	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 0));
-  writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
-  writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY0_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY1_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY2_LINEWIDTH_REG);
+	writel(par->mode.xres << 4, iomm.debe + DEBE_LAY3_LINEWIDTH_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_DISP_SIZE_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY0_SIZE_REG);
 	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY1_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY2_SIZE_REG);
+	writel((((par->mode.yres) - 1) << 16) | (((par->mode.xres) - 1) << 0), iomm.debe + DEBE_LAY3_SIZE_REG);
 	writel((5 << 8), iomm.debe + DEBE_LAY0_ATT_CTRL_REG1);
-  writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY1_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY2_ATT_CTRL_REG1);
+	writel((5 << 8), iomm.debe + DEBE_LAY3_ATT_CTRL_REG1);
 	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
 	suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 1));
-  suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
+	suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 1));
 
 	ret = readl(iomm.lcdc + TCON_CTRL_REG);
 	ret&= ~(1 << 0);
 	writel(ret, iomm.lcdc + TCON_CTRL_REG);
 	ret = (v_front_porch + v_back_porch + v_sync_len);
 
-    writel((uint32_t)(par->vram_phys) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
-    writel((uint32_t)(par->vram_phys + 320*240*2) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
-    writel((uint32_t)(par->vram_phys + 320*240*2) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) << 3, iomm.debe + DEBE_LAY0_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) << 3, iomm.debe + DEBE_LAY1_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) << 3, iomm.debe + DEBE_LAY2_FB_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) << 3, iomm.debe + DEBE_LAY3_FB_ADDR_REG);
+
+	writel((uint32_t)(par->vram_phys + 320*240*2*0) >> 29, iomm.debe + DEBE_LAY0_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*1) >> 29, iomm.debe + DEBE_LAY1_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*2) >> 29, iomm.debe + DEBE_LAY2_FB_HI_ADDR_REG);
+	writel((uint32_t)(par->vram_phys + 320*240*2*3) >> 29, iomm.debe + DEBE_LAY3_FB_HI_ADDR_REG);	
 	  
-    writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
+	writel((1 << 31) | ((ret & 0x1f) << 4) | (1 << 24), iomm.lcdc + TCON0_CTRL_REG);
 	  writel((0xf << 28) | (6 << 0), iomm.lcdc + TCON_CLK_CTRL_REG); // 6, 15
 	  writel((4 << 29) | (1 << 26), iomm.lcdc + TCON0_CPU_IF_REG);
 	  writel((1 << 28), iomm.lcdc + TCON0_IO_CTRL_REG0);
@@ -461,9 +488,9 @@ static void suniv_lcdc_init(struct myfb_par *par)
 	writel(((h_sync_len - 1) << 16) | ((v_sync_len - 1) << 0), iomm.lcdc + TCON0_BASIC_TIMING_REG3);
 	writel(0, iomm.lcdc + TCON0_HV_TIMING_REG);
 	writel(0, iomm.lcdc + TCON0_IO_CTRL_REG1);	
-  
+
 	suniv_setbits(iomm.lcdc + TCON_CTRL_REG, (1 << 31));
-  suniv_setbits(iomm.gpio + PE_INT_STA, (1 << 10));
+	suniv_setbits(iomm.gpio + PE_INT_STA, (1 << 10));
 	suniv_setbits(iomm.lcdc + TCON_INT_REG0, (1 << 31));
 	suniv_setbits(iomm.lcdc + TCON0_CPU_IF_REG, (1 << 28));
 }

--- a/drivers/video/fbdev/st7789sfb.c
+++ b/drivers/video/fbdev/st7789sfb.c
@@ -254,12 +254,29 @@ static void refresh_lcd(struct myfb_par *par)
     if (par->lcdc_ready) {
         lcdc_wr_cmd(0x2c);
   
-        if (par->app_virt->yoffset == 0) {
-	        suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	        suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
-        } else {
-	        suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
-	        suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+		if(par->app_virt->yoffset == 0) {
+            suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+        }
+        else if(par->app_virt->yoffset == 240) {
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+            suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+        }
+        else if(par->app_virt->yoffset == 480) {
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+            suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
+        }
+        else if(par->app_virt->yoffset == 720) {
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 8));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 9));
+            suniv_clrbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 10));
+            suniv_setbits(iomm.debe + DEBE_MODE_CTRL_REG, (1 << 11));
         }
 	    suniv_setbits(iomm.debe + DEBE_REGBUFF_CTRL_REG, (1 << 0));
     }


### PR DESCRIPTION
These layers are used by DirectFB to create graphical virtual terminals.